### PR TITLE
Pin pydicom dependency to pre-1.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 #
 #     pip install -U -r requirements.txt
 
-pydicom
+dicom==0.9.9.post1


### PR DESCRIPTION
As of pydicom v1.0, users are expected to `import pydicom` instead of `import dicom`. The maintainers of pydicom have created a dicom PyPi package that is compatible with pre-1.0 versions of the pydicom package.

For more information, see:
        https://pydicom.github.io/pydicom/stable/transition_to_pydicom1.html#for-authors-of-packages-requiring-pydicom-1-0
    and
        https://pypi.org/project/dicom/

Closes #22 